### PR TITLE
Add universal binary support for macOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,8 @@
 # (c) 1998--2024 Martin Mares <mj@ucw.cz>
 
 OPT=-O2
-CFLAGS=$(OPT) -Wall -W -Wno-parentheses -Wstrict-prototypes -Wmissing-prototypes
+CFLAGS=$(OPT) -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk -arch x86_64 -arch arm64 -Wall -W -Wno-parentheses -Wstrict-prototypes -Wmissing-prototypes
+TARGET_ARCH=-isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk -arch x86_64 -arch arm64
 
 VERSION=3.13.0
 DATE=2024-05-30

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -130,7 +130,7 @@ OBJS += dllrsrc
 endif
 CFLAGS += -fPIC -fvisibility=hidden
 $(PCILIB): $(addsuffix .o,$(OBJS))
-	$(CC) -shared $(CFLAGS) $(LDFLAGS) $(PCILIB_LDFLAGS) -o $@ $^ $(LIB_LDLIBS)
+	$(CC) -shared $(CFLAGS) $(LDFLAGS) $(TARGET_ARCH) $(PCILIB_LDFLAGS) -o $@ $^ $(LIB_LDLIBS)
 ifeq ($(LIBEXT),dll)
 $(PCILIB): build.def
 endif

--- a/lib/configure
+++ b/lib/configure
@@ -137,11 +137,13 @@ case $sys in
 		echo >>$c '#define PCI_HAVE_PM_DARWIN_DEVICE'
 		echo >>$m 'WITH_LIBS+=-lresolv -framework CoreFoundation -framework IOKit'
 		echo >>$c '#define PCI_HAVE_64BIT_ADDRESS'
-		echo_n " i386-ports"
-		echo >>$c '#define PCI_HAVE_PM_INTEL_CONF'
+		if [ "$cpu" = "i386" -o "$cpu" = "x86_64" ] ; then
+			echo_n " i386-ports"
+			echo >>$c '#define PCI_HAVE_PM_INTEL_CONF'
+		fi
 		LIBRESOLV=
 		LIBEXT=dylib
-		SYSINCLUDE=$(xcrun --sdk macosx --show-sdk-path 2> /dev/null || : )/usr/include
+		SYSINCLUDE=/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include
 		;;
 	aix)
 		echo_n " aix-device"

--- a/lib/configure
+++ b/lib/configure
@@ -143,7 +143,11 @@ case $sys in
 		fi
 		LIBRESOLV=
 		LIBEXT=dylib
-		SYSINCLUDE=/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include
+		# Try xcrun first, fall back to Command Line Tools SDK
+		SYSINCLUDE="$(xcrun --show-sdk-path 2>/dev/null)/usr/include"
+		if [ ! -d "$SYSINCLUDE" ]; then
+			SYSINCLUDE=/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include
+		fi
 		;;
 	aix)
 		echo_n " aix-device"


### PR DESCRIPTION
- Modified configure script to use Command Line Tools SDK
- Added -arch x86_64 -arch arm64 flags for universal binaries
- Updated Makefile to support both Intel and Apple Silicon architectures
- Fixed conditional compilation for ARM64 vs x86 architectures